### PR TITLE
Remove static ref to bot owner

### DIFF
--- a/Ping/Ping.py
+++ b/Ping/Ping.py
@@ -24,7 +24,7 @@ class Ping(commands.Cog):
     # TODO: implement a real ban system instead of this silly in-memory one
     @commands.command()
     async def unban(self, ctx: Context, member: Member):
-        if ctx.author.id != 108633439984439296:
+        if not await ctx.bot.is_owner(ctx.author):
             return
 
         if member.id in self.banned_users.keys():
@@ -33,7 +33,7 @@ class Ping(commands.Cog):
 
     @commands.command()
     async def ban(self, ctx: Context, member: Member):
-        if ctx.author.id != 108633439984439296:
+        if not await ctx.bot.is_owner(ctx.author):
             return
 
         if member.id not in self.banned_users.keys():


### PR DESCRIPTION
This is not to say that you, @RogueBurger, are not the ultimate owner of the DiscordWordleBot, however you are not the owner of my bot and I would like the privilege of banning offenders in my own server. :stuck_out_tongue_closed_eyes: 

But also, my kids made some avatars and I'll be implementing a command that allows the owner to cycle through them under a similar guard.