### PR TITLE
Add support for lowercase log levels

### DIFF
--- a/Config/Config.py
+++ b/Config/Config.py
@@ -28,28 +28,43 @@ class Config():
                  envvar_prefix: str = 'WORDLEBOT',
                  settings_files: list[str] = ['config.yaml']):
 
+        log_levels = ['DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL']
+
         config = LazySettings(
             load_dotenv=load_dotenv,
             envvar_prefix=envvar_prefix,
             settings_files=settings_files,
             validators=[
                 Validator('token', 'wordlist', required=True),
-                Validator('log_level', default='INFO', condition=lambda x: x in [
-                          'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL']),
+                Validator(
+                    'log_level',
+                    default='INFO',
+                    condition=lambda x: x.upper() in log_levels,
+                    messages={
+                        'condition': ' '.join([
+                            'Invalid {name} "{value}", must be one of: ',
+                            ', '.join(log_levels)
+                        ])
+                    }),
                 Validator('allow_channels', default=[]),
                 Validator('deny_channels', default=[]),
                 Validator('redis.enable', default=False),
                 Validator('redis.port', default=6379),
-                Validator('redis.host', 'redis.port',
-                          required=True,
-                          when=Validator('redis.enable', eq=True),
-                          messages={'must_exist_true': '{name} is required when redis is enabled'})
+                Validator(
+                    'redis.host', 'redis.port',
+                    required=True,
+                    when=Validator('redis.enable', eq=True),
+                    messages={
+                        'must_exist_true': '{name} is required when redis is enabled'
+                    })
             ])
 
         try:
             config.validators
         except ValidationError as e:
             raise ConfigValidationError(e)
+
+        config.log_level = config.log_level.upper()
 
         for field in self.__dataclass_fields__.keys():
             self.__setattr__(field, config.get(field))

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you already have a redis server running, just add its host and port to your c
 # config.yaml
 
 redis:
-    enabled: true
+    enable: true
     host: "redis.local"
     port: 6379
 ```
@@ -40,7 +40,7 @@ redis:
 ```.env
 # .env
 
-WORDLEBOT_REDIS__ENABLED="true"
+WORDLEBOT_REDIS__ENABLE="true"
 WORDLEBOT_REDIS__HOST="redis.local"
 WORDLEBOT_REDIS__PORT="6379"
 ```


### PR DESCRIPTION
The recently updated `config.yaml.example` file contains this invalid setting: 

```
log_level: info
```

The logging module only handles uppercase log level values, so if one were to attempt to run the bot based on a config modeled after `config.yaml.example` it would fail to start. 

This PR allows log level values to be specified in upper, lower, or mixed case.