### PR TITLE
Fix keyboard coloration bug

### DIFF
--- a/Wordle/Game.py
+++ b/Wordle/Game.py
@@ -148,11 +148,11 @@ class Game:
             status = item['status']
             existing = self.letter_status[letter]
 
-            if existing in [self.CORRECT, self.INVALID]:
-                continue
-
             if existing is None:
                 self.letter_status[letter] = status
+                continue
+
+            if existing == self.CORRECT:
                 continue
 
             if status in [self.CORRECT, self.INCORRECT]:


### PR DESCRIPTION
Fixes bug apparent in this image, where the `T` and `E` in the keyboard hint incorrectly indicate that the letters are invalid.
![image](https://user-images.githubusercontent.com/3260244/155220484-f62a4fdd-bacf-4c2c-b4b9-f6c001c9920e.png)
